### PR TITLE
feat(sign): Enable signatures for commits and tags

### DIFF
--- a/git/.gitconfig
+++ b/git/.gitconfig
@@ -41,6 +41,8 @@
 [commit]
 	verbose = true
 	gpgsign = true
+[tag]
+  gpgsign = true
 [submodule]
 	fetchJobs = 8
 [diff]
@@ -84,3 +86,6 @@
 	ui = auto
 [gpg]
 	format = ssh
+[gpg "ssh"]
+	#CHANGE PATH !!
+  ## allowedSignersFile = /Users/agravelot/.dotfiles/git/allowed_signers


### PR DESCRIPTION
Hello, :hand: 

In this PR, I suggest activating the signatures of your commits and tags :)

Prerequisites for this PR : 

- 1. Launch this command with your personnal path : 

```bash
echo "namespaces=\"git\" $(cat ~/.ssh/id_ed25519.pub)" > <PATH>/allowed_signers
```

- 2. Change ` allowedSignersFile` on your git configuration file with your path

- 3. To check that the signatures have been taken into account, run the command ` git log --show-signature` , you should found this line ` Good "git" signature for namespaces=git with ED25519 key SHA:256 ...` 

Enjoy :100: 